### PR TITLE
Apfelbaeumle

### DIFF
--- a/client/cache.js
+++ b/client/cache.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const Cache = class {
+
+    constructor(pk_fields, fields, id = "", counter = 0) {
+        for (const field of pk_fields) {
+            if (! fields.includes(field)) {
+                throw new Error(`pk ${field} does not exist in fields`);
+            }
+        };
+
+        this.pk_fields = pk_fields;
+        this.fields = fields;
+        this.id = id;
+        this.counter = counter;
+        this.map = new Map();
+    }
+
+    pk_to_key(pk) {
+        return pk.join("\x00");
+    }
+
+    entry_to_key(entry) {
+        return this.pk_fields.map( (field) => entry[field] ).join("\x00");
+    }
+
+    set(entry) {
+        return this.map.set(this.entry_to_key(entry), entry);
+    }
+
+    get(pk) {
+        return this.map.get(this.pk_to_key(pk));
+    }
+
+    has(pk) {
+        return this.map.has(this.pk_to_key(pk));
+    }
+
+    reset(id = "", counter = 0) {
+        this.map.clear();
+        this.id = id;
+        this.counter = counter;
+    }
+
+    insert_or_update(entries, counter) {
+        if (this.counter >= counter) {
+            return false;
+        }
+        for (const entry of entries) {
+            this.set(entry);
+        }
+        this.counter = counter;
+        return true;
+    }
+
+    keys() {
+        return this.map.keys();
+    }
+
+    entries() {
+        return this.map.entries();
+    }
+};
+

--- a/client/index.html
+++ b/client/index.html
@@ -15,6 +15,8 @@
 		<script src="domutil.js"></script>
 		<!-- websocket connection to server -->
 		<script src="wsclient.js"></script>
+		<!-- cache -->
+		<script src="cache.js"></script>
 		<!-- main logic for set_password.html -->
 		<script src="index.js"></script>
 		<!-- DOM manipulation and script initialization -->

--- a/client/index.js
+++ b/client/index.js
@@ -3,6 +3,10 @@ var store;
 
 // for this session only.
 var cache = {};
+cache.users = new Cache(["id"], ["id"]);
+cache.added_users = new Cache(["id"], ["id"]);
+cache.groups = new Cache(["id"], ["id"]);
+cache.group_memberships = new Cache(["uid", "gid"], ["uid", "gid"]);
 
 // the websocket client
 var client;
@@ -136,28 +140,119 @@ const connect = () => {
     }, true);
 
     client.srpcs.users_update = async (args) => {
-        for (added_user_update of args.added_users)
-        {
-            page.table_update_added_user(
-                added_user_update.id,
-                added_user_update.name,
-                added_user_update.email,
-                added_user_update.added,
-                added_user_update.activated
+        const added_users = args.added_users;
+        if (added_users.length > 0) {
+            const max_last_mod_seq = added_users[0].max_last_mod_seq;
+            cache.added_users.insert_or_update(added_users, max_last_mod_seq);
+
+            for (const added_user_update of added_users) {
+                page.table_update_added_user(
+                    added_user_update.id,
+                    added_user_update.name,
+                    added_user_update.email,
+                    added_user_update.added,
+                    added_user_update.activated
+                );
+            }
+        }
+
+        const my_account = args.my_account;
+        if (my_account) {
+            cache.my_account = my_account;
+            page.update_my_account(
+                my_account.id,
+                my_account.name,
+                my_account.email,
+                my_account.added,
+                my_account.added_by,
+                my_account.password_set,
+                my_account.email_update_request,
+                my_account.email_update_request_timestamp
             );
         }
 
-        if (args.my_account) {
-            page.update_my_account(
-                args.my_account.id,
-                args.my_account.name,
-                args.my_account.email,
-                args.my_account.added,
-                args.my_account.added_by,
-                args.my_account.password_set,
-                args.my_account.email_update_request,
-                args.my_account.email_update_request_timestamp
-            );
+        const users_of_groups_of_user = args.users;
+        if (users_of_groups_of_user.length > 0) {
+            const max_last_mod_seq = users_of_groups_of_user[0].max_last_mod_seq;
+            cache.users.insert_or_update(users_of_groups_of_user, max_last_mod_seq);
         }
     };
+
+    client.srpcs.groups_update = async (args) => {
+        // updates contain at least one entry !!!
+        const groups = args.groups;
+        const max_last_mod_seq = groups[0].max_last_mod_seq;
+
+        const changes = cache.groups.insert_or_update(groups, max_last_mod_seq);
+        if (! changes) {
+            return;
+        }
+
+        for (const group_update of groups) {
+            console.log("added group", group_update);
+        }
+    };
+
+    client.srpcs.group_memberships_update = async (args) => {
+        // updates contain at least one entry !!!
+        const group_memberships = args.group_memberships;
+        const max_last_mod_seq = group_memberships[0].max_last_mod_seq;
+
+        const changes = cache.group_memberships.insert_or_update(group_memberships, max_last_mod_seq);
+        if (! changes) {
+            return;
+        }
+
+        const missing_gids = group_memberships.map(
+            (elem) => (elem.gid)
+        ).filter(
+            (elem) => (! cache.groups.has([elem.gid]))
+        );
+        const missing_uids = group_memberships.map(
+            (elem) => (elem.uid)
+        ).filter(
+            (elem) => (! cache.users.has([elem.gid]))
+        );
+
+        if (missing_gids.length > 0) {
+            const missing_groups = (await client.crpc("get_groups_by_id", {
+                "ids": missing_gids,
+                "last_mod_seq": 0
+            })).groups;
+
+            if (missing_groups.length > 0) {
+                cache.groups.insert_or_update(missing_groups, missing_groups[0].max_last_mod_seq);
+            }
+            // FIXME: check if we did not get all groups
+        }
+
+        if (missing_uids.length > 0) {
+            const missing_users = (await client.crpc("get_users_by_id", {
+                "ids": missing_uids,
+                "last_mod_seq": 0
+            })).users;
+
+            if (missing_users.length > 0) {
+                cache.users.insert_or_update(missing_users, missing_users[0].max_last_mod_seq);
+            }
+            // FIXME: check if we did not get all users
+        }
+
+        for (const membership of group_memberships) {
+            let gid = membership.gid;
+            let uid = membership.uid;
+            console.log("added group_membership", membership);
+            if (! cache.groups.has([gid])) {
+                console.log("group is missing", gid);
+            } else {
+                console.log("group =", cache.groups.get([gid]));
+            }
+            if (! cache.users.has([uid])) {
+                console.log("user is missing", uid);
+            } else {
+                console.log("group =", cache.users.get([uid]));
+            }
+        }
+    };
+
 };

--- a/client/index.js
+++ b/client/index.js
@@ -114,6 +114,7 @@ const abort_update_email = async () => {
 const on_logged_in = async () => {
     await client.crpc("listen_users", {});
     await client.crpc("listen_groups", {});
+    await client.crpc("listen_group_memberships", {});
 };
 
 const connect = () => {

--- a/server/eval/typecheck.js
+++ b/server/eval/typecheck.js
@@ -16,8 +16,6 @@ module.exports.bool = (object) => (object === true) || (object === false);
 module.exports.number = Number.isFinite;
 module.exports.number_nonnegative = (object) => (Number.isFinite(object) && (object >= 0));
 module.exports.integer = Number.isInteger;
-module.exports.positive = (object) => (object > 0);
-module.exports.nonnegative = (object) => (object >= 0);
 module.exports.string = (object) => ((typeof object) === "string");
 module.exports.string_nz = (object) => (((typeof object) === "string") && (object !== ""));
 module.exports.string_re = (re) => (object) => (((typeof object) === "string") && object.match(re));
@@ -27,6 +25,10 @@ module.exports.choice = (set) => (object) => set.has(object);
 module.exports.optional = (inner_type) => (object) => ((object === undefined) || inner_type(object));
 module.exports.multicheck = (checks) => (object) => (checks.every( (check) => (check(object)) ));
 
+// these checks may only be used together with a check which ensures it is a number
+// for example: multicheck( [ integer, positive ] )
+module.exports.positive = (object) => (object > 0);
+module.exports.nonnegative = (object) => (object >= 0);
 
 module.exports.validate_object_structure = (object, types) => {
     // check that all required properties exist and have the correct type

--- a/server/eval/typecheck.js
+++ b/server/eval/typecheck.js
@@ -15,12 +15,17 @@ module.exports.object = (object) => ((typeof object === "object") && !Array.isAr
 module.exports.bool = (object) => (object === true) || (object === false);
 module.exports.number = Number.isFinite;
 module.exports.number_nonnegative = (object) => (Number.isFinite(object) && (object >= 0));
+module.exports.integer = Number.isInteger;
+module.exports.positive = (object) => (object > 0);
+module.exports.nonnegative = (object) => (object >= 0);
 module.exports.string = (object) => ((typeof object) === "string");
 module.exports.string_nz = (object) => (((typeof object) === "string") && (object !== ""));
 module.exports.string_re = (re) => (object) => (((typeof object) === "string") && object.match(re));
 module.exports.string_email = module.exports.string_re(/^[a-zA-Z0-9.+,-]+@[a-zA-Z0-9.-]+$/);
 module.exports.choice = (set) => (object) => set.has(object);
 module.exports.optional = (inner_type) => (object) => ((object === undefined) || inner_type(object));
+module.exports.multicheck = (checks) => (object) => (checks.every( (check) => (check(object)) ));
+
 
 module.exports.validate_object_structure = (object, types) => {
     // check that all required properties exist and have the correct type
@@ -67,3 +72,11 @@ module.exports.validate_email = (email) => {
         throw Error("bad email");
     }
 }
+
+/**
+ * ignores entries which are unset, that is: have never been assigned a value or the entry was deleted
+ * for a = [ 1, 2, , 4 ] only 1, 2 and 4 will be checked
+ * it though does check for entries which have an undefined value
+ * for a = [ 1, 2, undef, 4 ] all entries will be checked
+ */
+module.exports.array_of_type = (inner_type_check) => (object) => (Array.isArray(object) && object.every(inner_type_check, true));

--- a/server/eval/typecheck.js
+++ b/server/eval/typecheck.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 if (typeof module === "undefined") {
     // this file is shared between server and client.
@@ -47,7 +47,7 @@ module.exports.validate_object_structure = (object, types) => {
             throw new Error("superfluous object entry " + JSON.stringify(key) + ": " + JSON.stringify(object[key]));
         }
     }
-}
+};
 
 module.exports.empty_object = (object) => {
     // wtf @es6
@@ -62,19 +62,19 @@ module.exports.validate_uid = (uid) => {
     if (!module.exports.string_uid(uid)) {
         throw Error("bad user id");
     };
-}
+};
 
 module.exports.validate_username = (name) => {
     if (!module.exports.string_nz(name)) {
         throw Error("bad user name");
     };
-}
+};
 
 module.exports.validate_email = (email) => {
     if (!module.exports.string_email(email)) {
         throw Error("bad email");
     }
-}
+};
 
 /**
  * ignores entries which are unset, that is: have never been assigned a value or the entry was deleted

--- a/server/eval/typecheck.js
+++ b/server/eval/typecheck.js
@@ -22,6 +22,7 @@ module.exports.string = (object) => ((typeof object) === "string");
 module.exports.string_nz = (object) => (((typeof object) === "string") && (object !== ""));
 module.exports.string_re = (re) => (object) => (((typeof object) === "string") && object.match(re));
 module.exports.string_email = module.exports.string_re(/^[a-zA-Z0-9.+,-]+@[a-zA-Z0-9.-]+$/);
+module.exports.string_uid = module.exports.string_re(/^[a-zA-Z][a-zA-Z0-9_]*$/);
 module.exports.choice = (set) => (object) => set.has(object);
 module.exports.optional = (inner_type) => (object) => ((object === undefined) || inner_type(object));
 module.exports.multicheck = (checks) => (object) => (checks.every( (check) => (check(object)) ));
@@ -56,7 +57,7 @@ module.exports.empty_object = (object) => {
 };
 
 module.exports.validate_uid = (uid) => {
-    if (!/^[a-zA-Z][a-zA-Z0-9_]*$/.test(uid)) {
+    if (!module.exports.string_uid(uid)) {
         throw Error("bad user id");
     };
 }

--- a/server/main.js
+++ b/server/main.js
@@ -316,7 +316,7 @@ crpc_functions.listen_groups = async (connection, args) => {
     const last_mod_seq = new util.MonotonicNumber();
 
     const groups_update_callback = async () => {
-        const added_groups_updates = (await connection.db.query(
+        const groups_updates = (await connection.db.query(
             `
             with groups_of_user as (
                 select groups.*
@@ -345,10 +345,10 @@ crpc_functions.listen_groups = async (connection, args) => {
             [self_uid, last_mod_seq.get()]
         )).rows;
 
-        if (added_groups_updates.length > 0) {
-            last_mod_seq.bump(added_groups_updates[0].max_last_mod_seq);
+        if (groups_updates.length > 0) {
+            last_mod_seq.bump(groups_updates[0].max_last_mod_seq);
             await connection.supd("groups_update", {
-                added_groups: added_groups_updates,
+                groups: groups_updates,
             });
         }
     };
@@ -367,7 +367,7 @@ crpc_functions.listen_group_memberships = async (connection, args) => {
     const last_mod_seq = new util.MonotonicNumber();
 
     const group_memberships_update_callback = async () => {
-        const added_group_memberships_updates = (await connection.db.query(
+        const group_memberships_updates = (await connection.db.query(
             `
             with memberships as (
                 select * from group_memberships
@@ -389,10 +389,10 @@ crpc_functions.listen_group_memberships = async (connection, args) => {
             [self_uid, last_mod_seq.get()]
         )).rows;
 
-        if (added_group_memberships_updates.length > 0) {
-            last_mod_seq.bump(added_group_memberships_updates[0].max_last_mod_seq);
+        if (group_memberships_updates.length > 0) {
+            last_mod_seq.bump(group_memberships_updates[0].max_last_mod_seq);
             await connection.supd("group_memberships_update", {
-                added_group_memberships: added_group_memberships_updates,
+                group_memberships: group_memberships_updates,
             });
         }
     };

--- a/server/main.js
+++ b/server/main.js
@@ -450,7 +450,8 @@ crpc_functions.get_groups_by_id = async (connection, args) => {
 
     const self_uid = await connection.get_user();
 
-    const ids = args.ids.filter( () => true ); 		// make array dense: remove any elem which is unset
+    // make array dense: remove any elem which is unset
+    const ids = args.ids.filter( () => true );
 
     if (ids.length === 0) {
         return { "groups": [] };

--- a/server/main.js
+++ b/server/main.js
@@ -402,52 +402,6 @@ crpc_functions.listen_group_memberships = async (connection, args) => {
 };
 
 
-/*
-rpc_functions.listen_group_invites = async (connection, request) => {
-    await require_login(connection);
-    var updateDump = db.dumpUpdates(request.from);
-    for (let update of updateDump) {
-        update.type = "update";
-        update.contenthash = util.sha256(update.json + update.comment);
-        // TODO (data protection): decide whether this update concerns the user.
-        if (!true) {
-            delete update.json;
-            delete update.comment;
-        }
-        connection.sendUTF(JSON.stringify(update));
-    }
-    state.listeners[connection.connectionIdx] = connection;
-    return {pending: updateDump.length};
-};
-*/
-
-/*
-rpc_functions.add_update = async (connection, request) => {
-    // the user needs to be logged in to submit an update
-    var author = await requireLogin(connection);
-    // create the update, validate it, and apply it to the event cache
-    var update = updates.createAndApply(author, request.mode, request.json, request.comment, request.event, cache.events, cache.latestUpdateHash);
-    // write the update to the database
-    db.addUpdate(update);
-    cache.latestUpdateHash = updates.hash(update);
-    // send the update to all connected listeners
-    update.type = "update";
-    var updateJSON = JSON.stringify(update);
-    delete update.json;
-    delete update.comment;
-    var updateJSONCensored = JSON.stringify(update);
-    for (let connectionIdx of Object.keys(state.listeners)) {
-        // TODO (data protection): decide whether this update concerns the user.
-        if (true) {
-            state.listeners[connectionIdx].sendUTF(updateJSON);
-        } else {
-            state.listeners[connectionIdx].sendUTF(updateJSONCensored);
-        }
-    }
-    return { idx: update.idx, event: update.event };
-}
-*/
-
 const main = async() => {
     await websocket_server(on_open, crpc_functions, on_close);
 };

--- a/server/main.js
+++ b/server/main.js
@@ -1,10 +1,9 @@
-'use strict';
+"use strict";
 
 const util = require("./util.js");
-const cache = require("./cache.js");
 const websocket_server = require("./websocket_server.js");
 const typecheck = require("./eval/typecheck.js");
-const evaluate_group = require('./eval/group.js').evaluate;
+const evaluate_group = require("./eval/group.js").evaluate;
 
 
 const state = {
@@ -154,7 +153,7 @@ crpc_functions.set_password = async (connection, args) => {
     await connection.db.pop_set_password_token(args.uid, args.set_password_token);
 
     return await connection.db.set_password(args.uid, args.password);
-}
+};
 
 const ARGS_LISTEN_USERS = {};
 
@@ -444,6 +443,6 @@ rpc_functions.add_update = async (connection, request) => {
 
 const main = async() => {
     await websocket_server(on_open, crpc_functions, on_close);
-}
+};
 
-main().then(result => console.log("server is running"));
+main().then(() => console.log("server is running"));

--- a/server/main.js
+++ b/server/main.js
@@ -417,6 +417,9 @@ crpc_functions.listen_group_memberships = async (connection, args) => {
             select
                 gid,
                 uid,
+                added,
+                added_by,
+                role,
                 max_last_mod_seq
             from memberships, max_last_mod_seq
             order by

--- a/server/main.js
+++ b/server/main.js
@@ -157,6 +157,13 @@ crpc_functions.set_password = async (connection, args) => {
 
 const ARGS_LISTEN_USERS = {};
 
+/**
+ * It is no problem if a client calls this several times. If a client calls
+ * it, an already installed calback ist replaced by a new one and the
+ * counters are reset to 0 and so a complete update is sent.
+ * The old callback will be freed by as soon it completes.
+ * A client can use this behaviour to resync.
+ */
 crpc_functions.listen_users = async (connection, args) => {
     typecheck.validate_object_structure(args, ARGS_LISTEN_USERS);
 

--- a/server/main.js
+++ b/server/main.js
@@ -165,7 +165,7 @@ crpc_functions.listen_users = async (connection, args) => {
     const added_users_last_mod_seq = new util.MonotonicNumber();
     const my_account_last_mod_seq = new util.MonotonicNumber();
 
-    connection.users_update_callback = async () => {
+    const users_update_callback = async () => {
         const added_users_updates = (await connection.db.query(
             `
             with userentries as (
@@ -230,8 +230,8 @@ crpc_functions.listen_users = async (connection, args) => {
         }
     };
 
-    await connection.db.listen("users", connection.users_update_callback);
-    await connection.users_update_callback();
+    await connection.db.listen("users", users_update_callback);
+    await users_update_callback();
 };
 
 const ARGS_ADD_NEW_USER = {};
@@ -308,7 +308,7 @@ crpc_functions.listen_groups = async (connection, args) => {
 
     const last_mod_seq = new util.MonotonicNumber();
 
-    connection.groups_update_callback = async () => {
+    const groups_update_callback = async () => {
         const added_groups_updates = (await connection.db.query(
             `
             with groups_of_user as (
@@ -346,8 +346,8 @@ crpc_functions.listen_groups = async (connection, args) => {
         }
     };
 
-    await connection.db.listen("groups", connection.groups_update_callback);
-    await connection.groups_update_callback();
+    await connection.db.listen("groups", groups_update_callback);
+    await groups_update_callback();
 };
 
 const ARGS_LISTEN_GROUP_MEMBERSHIPS = {};
@@ -359,7 +359,7 @@ crpc_functions.listen_group_memberships = async (connection, args) => {
 
     const last_mod_seq = new util.MonotonicNumber();
 
-    connection.group_memberships_update_callback = async () => {
+    const group_memberships_update_callback = async () => {
         const added_group_memberships_updates = (await connection.db.query(
             `
             with memberships as (
@@ -390,8 +390,8 @@ crpc_functions.listen_group_memberships = async (connection, args) => {
         }
     };
 
-    await connection.db.listen("group_memberships", connection.group_memberships_update_callback);
-    await connection.group_memberships_update_callback();
+    await connection.db.listen("group_memberships", group_memberships_update_callback);
+    await group_memberships_update_callback();
 };
 
 

--- a/server/main.js
+++ b/server/main.js
@@ -230,6 +230,7 @@ crpc_functions.listen_users = async (connection, args) => {
             my_account_last_mod_seq.bump(my_account_update.last_mod_seq);
         }
 
+        // keep in sync with query in crpc_functions.get_users_by_id
         const users_update = (await connection.db.query(
             `
             with users_of_groups_of_user as (
@@ -353,6 +354,7 @@ crpc_functions.listen_groups = async (connection, args) => {
     const last_mod_seq = new util.MonotonicNumber();
 
     const groups_update_callback = async () => {
+        // keep in sync with query in crpc_functions.get_groups_by_id
         const groups_updates = (await connection.db.query(
             `
             with groups_of_user as (
@@ -460,6 +462,7 @@ crpc_functions.get_groups_by_id = async (connection, args) => {
     let paramnr = 2;
     const callparams = ids.map( () => "$"+(paramnr++) ).join(",");
 
+    // // keep in sync with query in crpc_functions.listen_groups
     const groups = (await connection.db.query(
         `
         with groups_of_user as (
@@ -510,6 +513,7 @@ crpc_functions.get_users_by_id = async (connection, args) => {
     let paramnr = 2;
     const callparams = ids.map( () => "$"+(paramnr++) ).join(",");
 
+    // keep in sync with query in crpc_functions.listen_users
     const users = (await connection.db.query(
         `
         with users_of_groups_of_user as (


### PR DESCRIPTION
* implement update for groups, group_membership in server
* change listen_users so that updates also send an update of the users a user is allowed to see as they are members of one of his groups
* implement some typechecks
* add crpc to request groups and users by ids. The server of course only sends them if the user is allowed to see them
* client: add a structure (cache) to store all actual valid data it got from the server
* client: implement listen_groups, listen_group_memberships (they simply store the updated into the cache and log it to the console, no visualisation yet)
* remove some dead code in server/main.js